### PR TITLE
config/exports: terminate exports file with a newline

### DIFF
--- a/manifests/config/exports.pp
+++ b/manifests/config/exports.pp
@@ -92,7 +92,7 @@ class nfs::config::exports (
     concat::fragment { "export for ${export}":
       target  => $config_file_real,
       order   => 50,
-      content => "\n\n${comment_real}\n${export_path_real}\t${clients_real}"
+      content => "\n\n${comment_real}\n${export_path_real}\t${clients_real}\n",
     }
   }
 }

--- a/spec/classes/config/exports_spec.rb
+++ b/spec/classes/config/exports_spec.rb
@@ -129,12 +129,12 @@ describe 'nfs::config::exports' do
         it {
           is_expected.to contain_concat__fragment('export for /tmp/some/path')
             .with_target('/etc/exports')
-            .with_content("\n\n#\n# Resource:/tmp/some/path\n/tmp/some/path	 10.0.0.1(rw,intr) 127.0.0.1(ro,bg)")
+            .with_content("\n\n#\n# Resource:/tmp/some/path\n/tmp/some/path	 10.0.0.1(rw,intr) 127.0.0.1(ro,bg)\n")
         }
         it {
           is_expected.to contain_concat__fragment('export for A title')
             .with_target('/etc/exports.d/puppet.exports')
-            .with_content("\n\n#\n# Resource:A title\n# Note this is here\n/real/path	 10.0.0.2(rw,intr) 127.0.0.2(ro,bg)")
+            .with_content("\n\n#\n# Resource:A title\n# Note this is here\n/real/path	 10.0.0.2(rw,intr) 127.0.0.2(ro,bg)\n")
         }
       end
     end


### PR DESCRIPTION
This way you don't get the dreaded "no newline at end of file" in the diff, and the text file is more properly formatted.
