### PR TITLE
Allow for disabling server services

### DIFF
--- a/data/os/Ubuntu/20.04.yaml
+++ b/data/os/Ubuntu/20.04.yaml
@@ -1,0 +1,3 @@
+---
+nfs::server_v4_helper_services:
+  - nfs-idmapd.service

--- a/manifests/config/exports.pp
+++ b/manifests/config/exports.pp
@@ -92,7 +92,7 @@ class nfs::config::exports (
     concat::fragment { "export for ${export}":
       target  => $config_file_real,
       order   => 50,
-      content => "\n\n${comment_real}\n${export_path_real}\t${clients_real}"
+      content => "\n\n${comment_real}\n${export_path_real}\t${clients_real}\n",
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -152,9 +152,9 @@ class nfs (
   Hash[String, Variant[Hash[String, Data], Undef]] $nfsmount_conf_hash,
   Hash[String, Hash[String, Data]] $vendor_nfsmount_conf_hash,
 ) {
-  contain '::nfs::install'
-  contain '::nfs::config'
-  contain '::nfs::service'
+  contain 'nfs::install'
+  contain 'nfs::config'
+  contain 'nfs::service'
 
   Class['nfs::install'] -> Class['nfs::config'] ~> Class['nfs::service']
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,9 +118,9 @@ class nfs (
   Boolean $manage_server_packages,
   Array[String[1]] $server_packages,
   Array[Systemd::Unit] $server_services,
-  Array[Systemd::Unit] $server_v3_helper_services,
-  Array[Systemd::Unit] $server_v4_helper_services,
-  Array[Systemd::Unit] $server_kerberos_services,
+  Optional[Array[Systemd::Unit]] $server_v3_helper_services,
+  Optional[Array[Systemd::Unit]] $server_v4_helper_services,
+  Optional[Array[Systemd::Unit]] $server_kerberos_services,
 
   Boolean $use_gssproxy,
   Hash[String, Variant[Data, Array[String[1]], Undef]] $gssproxy_services,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -71,7 +71,7 @@ class nfs::service (
   assert_private()
 
   if $server {
-    contain '::nfs::service::exportfs'
+    contain 'nfs::service::exportfs'
   }
 
   if $manage_services {
@@ -92,6 +92,6 @@ class nfs::service (
 
     # This is where we override the state
     # to start what we need
-    contain '::nfs::service::start'
+    contain 'nfs::service::start'
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -75,7 +75,6 @@ class nfs::service (
   }
 
   if $manage_services {
-
     # Set everything to 'off' and turn on only what we asked for
     # via a bunch of inheritance
     service { union($client_services

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -77,16 +77,20 @@ class nfs::service (
   if $manage_services {
     # Set everything to 'off' and turn on only what we asked for
     # via a bunch of inheritance
-    service { union($client_services
-                  , $client_v3_helper_services
-                  , $client_v4_helper_services
-                  , $client_kerberos_services
-                  , $server_services
-                  , $server_v3_helper_services
-                  , $server_v4_helper_services
-                  , $server_kerberos_services):
-      ensure => 'stopped',
-      enable => false,
+    (
+      $client_services
+      + $client_v3_helper_services
+      + $client_v4_helper_services
+      + $client_kerberos_services
+      + $server_services
+      + $server_v3_helper_services
+      + $server_v4_helper_services
+      + $server_kerberos_services
+    ).unique.filter |$i| { $i =~ NotUndef }.each |$svc| {
+      service { $svc:
+        ensure => stopped,
+        enable => false,
+      }
     }
 
     # This is where we override the state

--- a/metadata.json
+++ b/metadata.json
@@ -35,6 +35,12 @@
       "operatingsystemrelease": [
         "11"
       ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "20.04"
+      ]
     }
   ],
   "requirements": [

--- a/spec/classes/config/exports_spec.rb
+++ b/spec/classes/config/exports_spec.rb
@@ -129,12 +129,12 @@ describe 'nfs::config::exports' do
         it {
           is_expected.to contain_concat__fragment('export for /tmp/some/path')
             .with_target('/etc/exports')
-            .with_content("\n\n#\n# Resource:/tmp/some/path\n/tmp/some/path	 10.0.0.1(rw,intr) 127.0.0.1(ro,bg)")
+            .with_content("\n\n#\n# Resource:/tmp/some/path\n/tmp/some/path	 10.0.0.1(rw,intr) 127.0.0.1(ro,bg)\n")
         }
         it {
           is_expected.to contain_concat__fragment('export for A title')
             .with_target('/etc/exports.d/puppet.exports')
-            .with_content("\n\n#\n# Resource:A title\n# Note this is here\n/real/path	 10.0.0.2(rw,intr) 127.0.0.2(ro,bg)")
+            .with_content("\n\n#\n# Resource:A title\n# Note this is here\n/real/path	 10.0.0.2(rw,intr) 127.0.0.2(ro,bg)\n")
         }
       end
     end


### PR DESCRIPTION
- config/exports: terminate exports file with a newline
- add Ubuntu 20.04 "focal" support
- init: remove old-style top-level scope syntax
- init: allow for disabling server services
