### PR TITLE
data/common: don't ensure=>running on rpc-statd-notify.service

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -28,7 +28,6 @@ nfs::server_kerberos_services:
 
 nfs::server_v3_helper_services:
   - rpc-statd.service
-  - rpc-statd-notify.service
 
 nfs::server_v4_helper_services:
   - nfs-idmapd.service
@@ -47,7 +46,6 @@ nfs::client_kerberos_services:
 
 nfs::client_v3_helper_services:
   - rpc-statd.service
-  - rpc-statd-notify.service
 
 nfs::client_v4_helper_services:
   - nfs-blkmap.service


### PR DESCRIPTION
The `rpc-statd-notify.service` is normally not running, so every puppet run tries to start the service which causes a corrective change. `rpc-statd-notify.service` is automatically started by other NFS services when needed.

Reference: https://manpages.debian.org/stable/nfs-common/nfs.systemd.7.en.html#Enabling_unit_files

Quoting from that manual page:

> There are three unit files which are designed to be manually enabled. All others are automatically run as required. The three are `nfs-client.target`, `nfs-server.service`, and optionally (if using parallel NFS) `nfs-blkmap.service`.